### PR TITLE
[future] Avoid some future callback self-captures. (#36502)

### DIFF
--- a/torch/csrc/distributed/autograd/context/context.cpp
+++ b/torch/csrc/distributed/autograd/context/context.cpp
@@ -91,8 +91,9 @@ void DistAutogradContext::accumulateGrad(
       variable,
       old_grad,
       new_grad,
-      // Add +1 here since we can't std::move(grad) when call AccumulateGrad::callHooks,
-      // since it is a const ref, and that incurs a refcount bump for the new_grad.
+      // Add +1 here since we can't std::move(grad) when call
+      // AccumulateGrad::callHooks, since it is a const ref, and that incurs a
+      // refcount bump for the new_grad.
       num_expected_refs + 1,
       [this, &variable](at::Tensor&& grad_update) {
         accumulatedGrads_.insert(variable, std::move(grad_update));
@@ -122,25 +123,21 @@ void DistAutogradContext::resetGraphTask() {
 
 void DistAutogradContext::addOutstandingRpc(
     const std::shared_ptr<rpc::FutureMessage>& futureMessage) {
-  futureMessage->addCallback(
-      [this](
-          const rpc::Message& /* unused */,
-          const c10::optional<utils::FutureError>& futErr) {
-        if (futErr) {
-          // If we have an error, let the local autograd engine know about it.
-          std::runtime_error err((*futErr).what());
-          std::unique_lock<std::mutex> lock(lock_);
-          if (graphTask_) {
-            graphTask_->set_exception_without_signal(nullptr);
-            lock.unlock();
-            graphTask_->future_result_->setErrorIfNeeded(err.what());
-          } else {
-            LOG(WARNING)
-                << "Ignoring error since GraphTask is no longer valid: "
-                << err.what();
-          }
-        }
-      });
+  futureMessage->addCallback([this](const rpc::FutureMessage& futureMessage) {
+    if (futureMessage.hasError()) {
+      // If we have an error, let the local autograd engine know about it.
+      std::runtime_error err((*futureMessage.error()).what());
+      std::unique_lock<std::mutex> lock(lock_);
+      if (graphTask_) {
+        graphTask_->set_exception_without_signal(nullptr);
+        lock.unlock();
+        graphTask_->future_result_->setErrorIfNeeded(err.what());
+      } else {
+        LOG(WARNING) << "Ignoring error since GraphTask is no longer valid: "
+                     << err.what();
+      }
+    }
+  });
   std::lock_guard<std::mutex> guard(lock_);
   outStandingRpcs_.push_back(futureMessage);
 }
@@ -168,21 +165,20 @@ std::shared_ptr<rpc::FutureMessage> DistAutogradContext::
     state->future->markCompleted(rpc::Message());
   } else {
     for (auto& rpc : outStandingRpcs) {
-      rpc->addCallback([state](
-                           const rpc::Message& /* unused */,
-                           const c10::optional<utils::FutureError>& err) {
-        if (err) {
-          // If there's an error, we want to setError() on the future, unless
-          // another error has already been sent - use a CAS to guard.
+      rpc->addCallback([state](const rpc::FutureMessage& rpc) {
+        if (rpc.hasError()) {
+          // If there's an error, we want to setError() on the future,
+          // unless another error has already been sent - use a CAS to
+          // guard.
           //
-          // Don't decrement num remaining here! (We don't need to, since memory
-          // handling is separate). If we simply don't decrement on errors,
-          // reaching 0 means that there were no errors - and hence, we can just
-          // markCompleted() without any other checking there.
+          // Don't decrement num remaining here! (We don't need to, since
+          // memory handling is separate). If we simply don't decrement on
+          // errors, reaching 0 means that there were no errors - and hence,
+          // we can just markCompleted() without any other checking there.
           bool expectedAlreadySent = false;
           if (state->alreadySentError.compare_exchange_strong(
                   expectedAlreadySent, true)) {
-            state->future->setError(err->what());
+            state->future->setError(rpc.error()->what());
           }
           return;
         }

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -525,9 +525,16 @@ bool ProcessGroupAgent::handleRecv(RecvWork& work) {
       ++serverActiveAsyncCalls_;
       // Callback processing returned an incomplete future. Add sending the
       // response as a callback which fires when the future completes.
+      // Use a weak_ptr, so we can std::move the future's value.
       auto fromId = work.from_.id_;
       auto requestId = work.id_;
-      futureResponse->addCallback([this, fromId, requestId, futureResponse]() {
+      futureResponse->addCallback([this,
+                                   fromId,
+                                   requestId,
+                                   weak = std::weak_ptr<FutureMessage>(
+                                       futureResponse)]() {
+        auto futureResponse = weak.lock();
+        TORCH_INTERNAL_ASSERT(futureResponse);
         --serverActiveCalls_;
         --serverActiveAsyncCalls_;
         if (!futureResponse->hasError()) {

--- a/torch/csrc/distributed/rpc/python_functions.cpp
+++ b/torch/csrc/distributed/rpc/python_functions.cpp
@@ -157,7 +157,7 @@ PyRRef pyRemoteBuiltin(
         *agent, dst, std::move(*scriptRemoteCall).toMessage(), false, rf);
 
     ctx.addPendingUser(userRRef->forkId(), userRRef);
-    fm->addCallback([forkId{userRRef->forkId()}, fm]() {
+    fm->addCallback([forkId{userRRef->forkId()}](const FutureMessage& fm) {
       callback::confirmPendingUser(fm, forkId);
     });
     return PyRRef(userRRef);
@@ -173,7 +173,8 @@ PyRRef pyRemoteBuiltin(
 
     // Builtin operators does not return py::object, and hence does not require
     // GIL for destructing the potentially deleted OwerRRef.
-    fm->addCallback([fm]() { callback::finishCreatingOwnerRRef(fm); });
+    fm->addCallback(
+        [](const FutureMessage& fm) { callback::finishCreatingOwnerRRef(fm); });
     return PyRRef(ownerRRef);
   }
 }
@@ -214,7 +215,7 @@ PyRRef pyRemotePythonUdf(
         rf);
 
     ctx.addPendingUser(userRRef->forkId(), userRRef);
-    fm->addCallback([forkId{userRRef->forkId()}, fm]() {
+    fm->addCallback([forkId{userRRef->forkId()}](const FutureMessage& fm) {
       callback::confirmPendingUser(fm, forkId);
     });
     return PyRRef(userRRef);
@@ -229,7 +230,7 @@ PyRRef pyRemotePythonUdf(
         ownerRRef->rrefId().toIValue(),
         rf);
 
-    fm->addCallback([fm]() {
+    fm->addCallback([](const FutureMessage& fm) {
       auto deletedRRef = callback::finishCreatingOwnerRRef(fm);
       if (deletedRRef && deletedRRef->isPyObj()) {
         pybind11::gil_scoped_acquire ag;

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -69,8 +69,13 @@ std::shared_ptr<FutureMessage> RpcAgent::sendWithRetries(
       originalFuture,
       /* retryCount */ 0,
       retryOptions);
-
-  fm->addCallback([this, newTime, firstRetryRpc, fm]() {
+  // Use weak_ptr so that the value can be std::moved in rpcRetryCallback.
+  fm->addCallback([this,
+                   newTime,
+                   firstRetryRpc,
+                   weak = std::weak_ptr<FutureMessage>(fm)]() {
+    auto fm = weak.lock();
+    TORCH_INTERNAL_ASSERT(fm);
     rpcRetryCallback(fm, newTime, firstRetryRpc);
   });
 
@@ -133,7 +138,13 @@ void RpcAgent::retryExpiredRpcs() {
           earliestRpc->options_, earliestRpc->retryCount_);
       earliestRpc->retryCount_++;
 
-      fm->addCallback([this, newTime, earliestRpc, fm]() {
+      // Use weak_ptr so that the value can be std::moved in rpcRetryCallback.
+      fm->addCallback([this,
+                       newTime,
+                       earliestRpc,
+                       weak = std::weak_ptr<FutureMessage>(fm)]() {
+        auto fm = weak.lock();
+        TORCH_INTERNAL_ASSERT(fm);
         rpcRetryCallback(fm, newTime, earliestRpc);
       });
     }

--- a/torch/csrc/distributed/rpc/rref_context.h
+++ b/torch/csrc/distributed/rpc/rref_context.h
@@ -16,14 +16,14 @@ namespace rpc {
 namespace callback {
 // It's the callback for RemoteCall.
 void TORCH_API confirmPendingUser(
-    const std::shared_ptr<FutureMessage>& futureMessage,
+    const FutureMessage& futureMessage,
     const ForkId& expectedForkId);
 
 // It's the callback for finishing creating owner rref, it returned deletedRRef,
 // so that the deletedRRef can be handled under GIL in python_functions.cpp if
 // deletedRRef contains python object.
 c10::intrusive_ptr<RRef> TORCH_API
-finishCreatingOwnerRRef(const std::shared_ptr<FutureMessage>& futureMessage);
+finishCreatingOwnerRRef(const FutureMessage& futureMessage);
 } // namespace callback
 
 // Manages RRef lifetime and keeps track of RRef forks.
@@ -38,7 +38,7 @@ class TORCH_API RRefContext {
   static std::vector<c10::intrusive_ptr<RRef>> destroyInstance(
       bool ignoreRRefLeak = true);
 
-  static void handleException(const std::shared_ptr<FutureMessage>& fm);
+  static void handleException(const FutureMessage& fm);
 
   RRefContext(const RRefContext&) = delete;
   RRefContext(RRefContext&& other) = delete;

--- a/torch/csrc/utils/future.h
+++ b/torch/csrc/utils/future.h
@@ -128,13 +128,11 @@ class TORCH_API Future final {
     callbacks_.emplace_back(std::move(cb));
   }
 
-  // Remove this once we've migrated underlying use-cases.
-  void addCallback(const std::function<
-                   void(const T&, const c10::optional<torch::utils::FutureError>&)>& cb) {
-    addCallback([cb,this]() { cb(value_, error_); });
+  void addCallback(std::function<void(const Future<T>& future)> cb) {
+    addCallback([this, cb]() { cb(*this); });
   }
 
-  private:
+ private:
   void setErrorInternal(
       FutureError error,
       std::unique_lock<std::mutex>& lock) {


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/36502

We're sometimes deleting futures without completing them (discovered by logging),
and we've recently noticed a slow memory leak.

This change migrates the future lambda cases where there was self-capture.
 - In some cases, we use weak_ptr<>, plus .lock()/assert in the lambda callback.
   This avoids the reference cycle. We use this primarily in the case where the
   value ends up being moved in the callback (something we want to be careful about)

 - We also add a convenience api to Future where the completed Future is returned as an arg.
   This allows us to avoid self-capture, though it assumes that the markCompleted()
   caller is persisting the future for the markCompleted() duration (this has been the case)

ghstack-source-id: 102130672

Test Plan: ctr_mobile_feed, buck test mode/dev-nosan caffe2/test/...

Differential Revision: D20998905

fbshipit-source-id: 7dd52fe4e567a5dea20e8d43862fc2335fd3ce16

